### PR TITLE
refactor: modularize full exam flow

### DIFF
--- a/src/pages/exam/steps.tsx
+++ b/src/pages/exam/steps.tsx
@@ -1,0 +1,62 @@
+import QuestionCard from '../../components/exam/QuestionCard';
+import ReactionTest from '../../components/psycho/ReactionTest';
+import ConstantVelocityOcclusionTest from '../../components/psycho/ConstantVelocityOcclusionTest';
+import CoordinationTest from '../../components/psycho/CoordinationTest';
+import AttentionReactionTest from '../../components/psycho/AttentionReactionTest';
+import type { Question } from '../../types';
+
+export function TheoryStep({
+  question,
+  selected,
+  onSelect,
+}: {
+  question: Question;
+  selected: number | null;
+  onSelect: (sel: number) => void;
+}) {
+  return <QuestionCard q={question} selected={selected} onSelect={onSelect} />;
+}
+
+export function SignsStep({
+  question,
+  selected,
+  onSelect,
+}: {
+  question: Question;
+  selected: number | null;
+  onSelect: (sel: number) => void;
+}) {
+  return <QuestionCard q={question} selected={selected} onSelect={onSelect} />;
+}
+
+export function ReactionStep({
+  onComplete,
+}: {
+  onComplete: (sum: unknown) => void;
+}) {
+  return <ReactionTest compact onComplete={onComplete} />;
+}
+
+export function VelocityStep({
+  onComplete,
+}: {
+  onComplete: (sum: unknown) => void;
+}) {
+  return <ConstantVelocityOcclusionTest compact onComplete={onComplete} />;
+}
+
+export function CoordStep({
+  onComplete,
+}: {
+  onComplete: (sum: unknown) => void;
+}) {
+  return <CoordinationTest compact onComplete={onComplete} />;
+}
+
+export function AttentionStep({
+  onComplete,
+}: {
+  onComplete: (sum: unknown) => void;
+}) {
+  return <AttentionReactionTest compact onComplete={onComplete} />;
+}

--- a/src/pages/exam/useExamSteps.ts
+++ b/src/pages/exam/useExamSteps.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useExamSteps<T>(steps: T[]) {
+  const [idx, setIdx] = useState(0);
+  const completedRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    setIdx(0);
+    completedRef.current.clear();
+  }, [steps]);
+
+  const total = steps.length || 1;
+  const step = steps[idx];
+
+  const goNext = () => setIdx(i => Math.min(total - 1, i + 1));
+  const goPrev = () => setIdx(i => Math.max(0, i - 1));
+
+  const advanceOnceFrom = (fromIndex: number, after?: () => void) => {
+    if (completedRef.current.has(fromIndex)) return;
+    completedRef.current.add(fromIndex);
+    after?.();
+    setIdx(i => Math.min(total - 1, i + 1));
+  };
+
+  const restart = () => {
+    setIdx(0);
+    completedRef.current.clear();
+  };
+
+  return { idx, step, total, goNext, goPrev, advanceOnceFrom, restart };
+}

--- a/src/utils/normalizers.ts
+++ b/src/utils/normalizers.ts
@@ -1,0 +1,113 @@
+export type ReactionSummary = {
+  attempts: { rt: number | null; tooSoon: boolean }[];
+  meanRt: number | null;
+  pass: boolean;
+};
+export type OcclusionSummary = {
+  attempts: { hit: boolean; spatialErrorPct: number; timeout: boolean }[];
+  pass: boolean;
+  thresholdPct: number;
+};
+export type CoordSummary = {
+  completed: boolean;
+  left: { outsideSec: number; exits: number };
+  right: { outsideSec: number; exits: number };
+  pass?: boolean;
+};
+export type AttentionSummary = {
+  acc: number;
+  meanRt: number | null;
+  hits: number;
+  misses: number;
+  falseAlarms: number;
+  correctInhibitions: number;
+  pass: boolean;
+};
+
+export function normalizeReactionSummary(payload: unknown): ReactionSummary {
+  const PASS_RT_MS = 600;
+  if (payload && typeof payload === 'object' && Array.isArray((payload as any).attempts)) {
+    const p: any = payload;
+    const attempts = p.attempts.map((a: any) => ({
+      rt: typeof a?.rt === 'number' ? a.rt : null,
+      tooSoon: !!a?.tooSoon
+    }));
+    const meanRt =
+      typeof p.meanRt === 'number'
+        ? p.meanRt
+        : (attempts.filter((a: any) => a.rt != null).length
+            ? attempts.reduce((acc: number, a: any) => acc + (a.rt ?? 0), 0) /
+              attempts.filter((a: any) => a.rt != null).length
+            : null);
+    const pass = typeof p.pass === 'boolean' ? p.pass : (meanRt !== null && meanRt <= PASS_RT_MS);
+    return { attempts, meanRt, pass };
+  }
+  if (typeof payload === 'number' || payload === null) {
+    const rt = payload === null ? null : payload;
+    const pass = rt !== null && rt <= PASS_RT_MS;
+    return { attempts: [{ rt, tooSoon: false }], meanRt: rt, pass };
+  }
+  if (payload && typeof payload === 'object') {
+    const p: any = payload;
+    const rt = typeof p.ms === 'number' ? p.ms : (typeof p.meanRt === 'number' ? p.meanRt : null);
+    const pass = typeof p.pass === 'boolean' ? p.pass : (rt !== null && rt <= PASS_RT_MS);
+    return { attempts: [{ rt, tooSoon: false }], meanRt: rt, pass };
+  }
+  return { attempts: [], meanRt: null, pass: false };
+}
+
+export function normalizeOcclusionSummary(payload: unknown): OcclusionSummary {
+  const DEFAULT_THRESHOLD = 50;
+  if (payload && typeof payload === 'object') {
+    const p: any = payload;
+    if (Array.isArray(p.attempts)) {
+      return {
+        attempts: p.attempts.map((a: any) => ({
+          hit: !!a?.hit,
+          spatialErrorPct: typeof a?.spatialErrorPct === 'number' ? a.spatialErrorPct : (a?.errorPct ?? 0),
+          timeout: !!a?.timeout
+        })),
+        pass: !!p.pass,
+        thresholdPct: typeof p.thresholdPct === 'number' ? p.thresholdPct : DEFAULT_THRESHOLD
+      };
+    }
+    if (typeof p.avgError === 'number') {
+      const thr = typeof p.thresholdPct === 'number' ? p.thresholdPct : DEFAULT_THRESHOLD;
+      return {
+        attempts: [{ hit: p.avgError <= thr, spatialErrorPct: p.avgError, timeout: false }],
+        pass: !!p.pass,
+        thresholdPct: thr
+      };
+    }
+  }
+  return { attempts: [], pass: false, thresholdPct: DEFAULT_THRESHOLD };
+}
+
+export function normalizeCoordSummary(payload: unknown): CoordSummary {
+  if (payload && typeof payload === 'object') {
+    const p: any = payload;
+    return {
+      completed: !!p.completed,
+      left: { outsideSec: Number(p?.left?.outsideSec ?? 0), exits: Number(p?.left?.exits ?? 0) },
+      right:{ outsideSec: Number(p?.right?.outsideSec ?? 0), exits: Number(p?.right?.exits ?? 0) },
+      pass: typeof p.pass === 'boolean' ? p.pass : !!p.completed
+    };
+  }
+  return { completed: false, left: { outsideSec: 0, exits: 0 }, right: { outsideSec: 0, exits: 0 }, pass: false };
+}
+
+export function normalizeAttentionSummary(payload: unknown): AttentionSummary {
+  if (payload && typeof payload === 'object') {
+    const p: any = payload;
+    return {
+      acc: Number(p.acc ?? 0),
+      meanRt: typeof p.meanRt === 'number' ? p.meanRt : null,
+      hits: Number(p.hits ?? 0),
+      misses: Number(p.misses ?? 0),
+      falseAlarms: Number(p.falseAlarms ?? 0),
+      correctInhibitions: Number(p.correctInhibitions ?? 0),
+      pass: !!p.pass
+    };
+  }
+  return { acc: 0, meanRt: null, hits: 0, misses: 0, falseAlarms: 0, correctInhibitions: 0, pass: false };
+}

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,15 @@
+export function fyShuffle<T>(arr: T[]): T[] {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = a[i] as T;
+    a[i] = a[j] as T;
+    a[j] = tmp;
+  }
+  return a;
+}
+
+export function pickRandom<T>(arr: T[], n: number): T[] {
+  const m = Math.max(0, Math.min(n, arr.length));
+  return fyShuffle(arr).slice(0, m);
+}

--- a/src/utils/score.ts
+++ b/src/utils/score.ts
@@ -1,0 +1,10 @@
+export type ResultLike = { ok: boolean };
+
+export function theoryOk(items: ResultLike[]): number {
+  return items.filter(r => r.ok).length;
+}
+
+export function pct(ok: number, total: number): number {
+  const t = total || 1;
+  return Math.round((ok / t) * 100);
+}


### PR DESCRIPTION
## Summary
- modularize theory, sign, and psycho exam steps into their own components
- manage step progression with new `useExamSteps` hook
- relocate normalizers and helpers to `src/utils` and fix `theoryOk` naming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a40b102294832ba81dab7b575b32cb