### PR TITLE
feat: add dark mode toggle and modernize UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,17 @@
   </head>
   <body class="bg-background text-foreground">
     <div id="root"></div>
+    <script>
+      (() => {
+        const stored = localStorage.getItem('theme')
+        if (
+          stored === 'dark' ||
+          (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        ) {
+          document.documentElement.classList.add('dark')
+        }
+      })()
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,13 +8,13 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
 export default function Button({ className, variant = 'primary', ...rest }: Props) {
   const styles =
     variant === 'primary'
-      ? 'bg-primary text-white hover:opacity-90 focus:ring-2 focus:ring-primary/50'
+      ? 'bg-primary text-white hover:opacity-90 focus:ring-2 focus:ring-primary/50 shadow-sm'
       : 'bg-transparent text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-2 focus:ring-primary/50'
   return (
     <button
       {...rest}
       className={cn(
-        'px-4 py-2 rounded-base transition-all duration-200 active:scale-[0.98]',
+        'px-4 py-2 rounded-base transition-all duration-200 active:scale-[0.98] font-medium',
         styles,
         className
       )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import LanguageSelector from './LanguageSelector'
+import ThemeToggle from './ThemeToggle'
 import { TabNav, TabItem } from '../ui'
 
 export default function Header() {
@@ -12,7 +13,7 @@ export default function Header() {
   ]
   const current = loc.pathname.includes('/simulador') ? 'exam' : 'study'
   return (
-    <header className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b border-gray-200 dark:border-gray-700">
+    <header className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b border-gray-200 dark:border-gray-700 shadow-sm">
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
         <Link to="/" className="font-semibold text-lg" aria-label={t('appTitle')}>
           {t('appTitle')}
@@ -21,6 +22,7 @@ export default function Header() {
           <Link className="hover:underline" to="/estudio">{t('nav.study')}</Link>
           <Link className="hover:underline" to="/simulador">{t('nav.exam')}</Link>
           <LanguageSelector />
+          <ThemeToggle />
         </div>
       </div>
       {/* tabs móviles */}

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -8,10 +8,10 @@ const langs = [
 export default function LanguageSelector() {
   const { i18n } = useTranslation()
   return (
-    <label className="inline-flex items-center gap-2">
+    <label className="inline-flex items-center">
       <span className="sr-only">Idioma</span>
       <select
-        className="rounded-lg border-gray-300"
+        className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-background dark:bg-gray-800 text-sm transition-colors"
         value={i18n.language}
         onChange={(e) => i18n.changeLanguage(e.target.value)}
         aria-label="Idioma"

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+
+const STORAGE_KEY = 'theme'
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    const prefersDark = stored
+      ? stored === 'dark'
+      : window.matchMedia('(prefers-color-scheme: dark)').matches
+    document.documentElement.classList.toggle('dark', prefersDark)
+    setDark(prefersDark)
+  }, [])
+
+  const toggle = () => {
+    const newDark = !dark
+    document.documentElement.classList.toggle('dark', newDark)
+    localStorage.setItem(STORAGE_KEY, newDark ? 'dark' : 'light')
+    setDark(newDark)
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-background hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors"
+      aria-label={dark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'}
+    >
+      {dark ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />}
+    </button>
+  )
+}
+

--- a/src/components/exam/OptionsList.tsx
+++ b/src/components/exam/OptionsList.tsx
@@ -26,7 +26,7 @@ export default function OptionsList({ options, selected, onSelect }: Props) {
               onKeyDown={handleKey(idx)}
               onClick={() => onSelect(idx)}
               className={
-                'w-full text-left border rounded-base px-4 py-3 transition-colors ' +
+                'w-full text-left border rounded-base px-4 py-3 transition-colors text-foreground ' +
                 (isSel
                   ? 'border-primary bg-primary/10'
                   : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700')

--- a/src/components/exam/QuestionCard.tsx
+++ b/src/components/exam/QuestionCard.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export default function QuestionCard({ q, selected, onSelect, feedback }: Props) {
   return (
-    <article className="rounded-2xl border border-gray-200 p-4 sm:p-6 bg-white shadow-sm">
+    <article className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-background p-4 sm:p-6 shadow-sm">
       <header className="mb-3">
         <h2 className="text-lg font-semibold">{q.texto}</h2>
       </header>

--- a/src/components/psycho/AttentionReactionTest.tsx
+++ b/src/components/psycho/AttentionReactionTest.tsx
@@ -260,13 +260,17 @@ export default function AttentionReactionTest({
   }, [])
 
   return (
-    <div className="rounded-2xl border p-4 sm:p-6 bg-white shadow-sm">
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 sm:p-6 bg-background shadow-sm">
       {!compact && <h2 className="text-lg font-semibold mb-2">Atención + Reacción</h2>}
 
-      <canvas ref={canvasRef} className="w-full block border rounded" aria-label="Responde al estímulo." />
+      <canvas
+        ref={canvasRef}
+        className="w-full block border border-gray-300 dark:border-gray-600 rounded bg-background"
+        aria-label="Responde al estímulo."
+      />
 
       {!compact && (
-        <p className="mt-2 text-sm text-gray-600">
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
           Círculo amarillo → “Círculo” (F). Triángulo azul → “Triángulo” (J). Cuadrado rojo → no presionar.
         </p>
       )}
@@ -278,8 +282,18 @@ export default function AttentionReactionTest({
 
         {phase === 'stim' && (
           <>
-            <button className="px-4 py-2 rounded-xl border" onClick={() => handleResponse('circle')}>Círculo</button>
-            <button className="px-4 py-2 rounded-xl border" onClick={() => handleResponse('triangle')}>Triángulo</button>
+            <button
+              className="px-4 py-2 rounded-xl border border-gray-300 dark:border-gray-600 bg-background text-foreground"
+              onClick={() => handleResponse('circle')}
+            >
+              Círculo
+            </button>
+            <button
+              className="px-4 py-2 rounded-xl border border-gray-300 dark:border-gray-600 bg-background text-foreground"
+              onClick={() => handleResponse('triangle')}
+            >
+              Triángulo
+            </button>
           </>
         )}
 
@@ -289,7 +303,7 @@ export default function AttentionReactionTest({
       </div>
 
       {phase === 'finished' && !compact && (
-        <div className="mt-4 rounded-xl border p-3 text-sm">
+        <div className="mt-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-background p-3 text-sm">
           <p className="font-semibold mb-1">Test finalizado</p>
           <ul className="ml-5 list-disc">
             <li>Aciertos: {hitsRef.current}</li>

--- a/src/components/psycho/ConstantVelocityOcclusionTest.tsx
+++ b/src/components/psycho/ConstantVelocityOcclusionTest.tsx
@@ -160,13 +160,13 @@ export default function ConstantVelocityOcclusionTest({
   const finished = results.length >= attempts
 
   return (
-    <div className="rounded-2xl border p-4 sm:p-6 bg-white shadow-sm">
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 sm:p-6 bg-background shadow-sm">
       {!compact && <h2 className="text-lg font-semibold mb-2">Velocidad constante (ocultamiento)</h2>}
       <canvas
         ref={canvasRef}
         width={width}
         height={height}
-        className="mx-auto block border rounded"
+        className="mx-auto block border border-gray-300 dark:border-gray-600 rounded bg-background"
         onClick={() => {
           if (finished) return
           if (!running) startAttempt()
@@ -185,7 +185,7 @@ export default function ConstantVelocityOcclusionTest({
       />
 
       {!compact && (
-        <div className="mt-3 text-sm text-gray-600">
+        <div className="mt-3 text-sm text-gray-600 dark:text-gray-400">
           <p>Intento {Math.min(results.length + 1, attempts)} / {attempts}</p>
           <p>Click/Space para iniciar y detener. Timeout: {timeoutSec}s. Tamaño: {squareSize}px. Target 30px.</p>
         </div>
@@ -202,7 +202,7 @@ function ResultsPanel({ results }: { results: AttemptResult[] }) {
   const avg = results.reduce((a, r) => a + r.errorPercent, 0) / results.length
   const pass = avg <= 50
   return (
-    <div className="mt-4 rounded-xl border p-3">
+    <div className="mt-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-background p-3">
       <p className="font-semibold">Resumen</p>
       <ul className="list-disc ml-5 text-sm">
         {results.map((r, i) => (

--- a/src/components/psycho/CoordinationTest.tsx
+++ b/src/components/psycho/CoordinationTest.tsx
@@ -500,7 +500,7 @@ export default function CoordinationTest({
     function TouchHoldBtn({ label, onHoldChange }: { label: string; onHoldChange: (down: boolean) => void }) {
         return (
             <button
-                className="px-4 py-3 rounded-lg border select-none"
+                className="px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-background text-foreground select-none"
                 onMouseDown={() => onHoldChange(true)}
                 onMouseUp={() => onHoldChange(false)}
                 onMouseLeave={() => onHoldChange(false)}
@@ -513,18 +513,18 @@ export default function CoordinationTest({
     }
 
     return (
-        <div className="rounded-2xl border p-4 sm:p-6 bg-white shadow-sm">
+        <div className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 sm:p-6 bg-background shadow-sm">
             {!compact && <h2 className="text-lg font-semibold mb-2">Coordinación bimanual</h2>}
 
             <canvas
                 ref={canvasRef}
-                className="w-full block border rounded"
+                className="w-full block border border-gray-300 dark:border-gray-600 rounded bg-background"
                 tabIndex={0}
                 aria-label="Mantén los cuadrados dentro de sus carriles. A/D para izquierdo, J/L para derecho."
             />
 
             {!compact && (
-                <p className="mt-2 text-sm text-gray-600">
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
                     A/D (izq) · J/L (der). Dura {durationSec}s. Descalifica si permanecés fuera {maxOutsideSec}s acumulados.
                 </p>
             )}
@@ -543,11 +543,11 @@ export default function CoordinationTest({
 
             <div className="mt-3 flex gap-2">
                 {!running && <button className="px-4 py-2 rounded-xl bg-blue-600 text-white" onClick={start}>Iniciar</button>}
-                {running && <button className="px-4 py-2 rounded-xl border" onClick={() => stop(false)}>Interrumpir</button>}
+                {running && <button className="px-4 py-2 rounded-xl border border-gray-300 dark:border-gray-600" onClick={() => stop(false)}>Interrumpir</button>}
             </div>
 
             {completed && !compact && (
-                <div className="mt-3 rounded-xl border p-3 text-sm">
+                <div className="mt-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-background p-3 text-sm">
                     <p className="font-semibold">Resumen</p>
                     <ul className="ml-5 list-disc">
                         <li>Izq: fuera {leftOutsideRef.current.toFixed(2)}s · salidas {leftExitsRef.current}</li>

--- a/src/components/psycho/ReactionTest.tsx
+++ b/src/components/psycho/ReactionTest.tsx
@@ -145,13 +145,13 @@ export default function ReactionTest({
   }, [finished, phase])
 
   return (
-    <div className="rounded-2xl border p-4 sm:p-6 bg-white shadow-sm">
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 sm:p-6 bg-background shadow-sm">
       {!compact && <h2 className="text-lg font-semibold mb-2">{t('psycho.reaction.title')}</h2>}
-      {!compact && <p className="text-sm text-gray-600 mb-4">{t('psycho.reaction.desc')}</p>}
+      {!compact && <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">{t('psycho.reaction.desc')}</p>}
 
       {/* Progreso */}
       {!finished && (
-        <p className="text-xs text-gray-500 mb-2">
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
           Intento {trialIdx + 1} de {trialsCount}
         </p>
       )}
@@ -189,7 +189,7 @@ export default function ReactionTest({
 
       {/* Resumen final (práctica) */}
       {finished && !compact && (
-        <div className="mt-4 rounded-xl border p-3 text-sm">
+        <div className="mt-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-background p-3 text-sm">
           <p className="font-semibold mb-2">Resumen</p>
           <ul className="ml-5 list-disc">
             <li>Intentos: {trialsCount}</li>

--- a/src/pages/StudyPage.tsx
+++ b/src/pages/StudyPage.tsx
@@ -32,7 +32,7 @@ export default function StudyPage() {
       <h1 className="text-2xl font-bold mb-4">{t('nav.study')}</h1>
       <TabNav items={tabs} current={tab} onChange={(id) => setTab(id as Tab)} className="mb-4" />
 
-      <div className="prose max-w-none">
+      <div className="prose dark:prose-invert max-w-none">
         {sections.map((s, i) => (
           <section key={i} className="mb-6">
             <h2>{s.titulo}</h2>

--- a/src/pages/exam/FullExamPage.tsx
+++ b/src/pages/exam/FullExamPage.tsx
@@ -217,12 +217,12 @@ export default function FullExamPage() {
 
       {/* Resumen */}
       {step?.type === 'summary' && (
-        <div className="rounded-2xl border p-4 sm:p-6 bg-white shadow-sm space-y-6">
+        <div className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 sm:p-6 bg-background shadow-sm space-y-6">
           <h2 className="text-xl font-semibold">Resumen del examen</h2>
 
           <div>
             <h3 className="font-semibold mb-2">Preguntas teóricas</h3>
-            <p className="text-sm text-gray-700 mb-2">
+            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
                 Correctas: {theoryOk(theoryResults)}/{theoryResults.length} ({pct(theoryOk(theoryResults), theoryResults.length)}%) ·
               Umbral: {Math.round(THEORY_PASS_RATIO*100)}% · {theoryPass ? 'Aprobado' : 'No aprobado'}
             </p>
@@ -234,7 +234,7 @@ export default function FullExamPage() {
                     <span className={r.ok ? 'text-green-700' : 'text-red-700'}>
                       Tu respuesta: {r.elegida !== null ? r.opciones[r.elegida] : '—'} {r.ok ? '✓' : '✗'}
                     </span>
-                    {!r.ok && <span className="text-gray-700"> • Correcta: {r.opciones[r.correcta]}</span>}
+                    {!r.ok && <span className="text-gray-700 dark:text-gray-300"> • Correcta: {r.opciones[r.correcta]}</span>}
                   </div>
                 </li>
               ))}
@@ -243,7 +243,7 @@ export default function FullExamPage() {
 
           <div>
             <h3 className="font-semibold mb-2">Preguntas sobre señales</h3>
-            <p className="text-sm text-gray-700 mb-2">
+            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
                 Correctas: {theoryOk(signsResults)}/{signsResults.length} ({pct(theoryOk(signsResults), signsResults.length)}%) ·
               Umbral: {Math.round(SIGNS_PASS_RATIO*100)}% · {signsPass ? 'Aprobado' : 'No aprobado'}
             </p>
@@ -255,7 +255,7 @@ export default function FullExamPage() {
                     <span className={r.ok ? 'text-green-700' : 'text-red-700'}>
                       Tu respuesta: {r.elegida !== null ? r.opciones[r.elegida] : '—'} {r.ok ? '✓' : '✗'}
                     </span>
-                    {!r.ok && <span className="text-gray-700"> • Correcta: {r.opciones[r.correcta]}</span>}
+                    {!r.ok && <span className="text-gray-700 dark:text-gray-300"> • Correcta: {r.opciones[r.correcta]}</span>}
                   </div>
                 </li>
               ))}
@@ -273,7 +273,7 @@ export default function FullExamPage() {
                   <li>RT medio: {reactSum.meanRt !== null ? `${Math.round(reactSum.meanRt)} ms` : '—'}</li>
                   <li>Resultado: {reactSum.pass ? 'Aprobado' : 'No aprobado'}</li>
                 </ul>
-              ) : <p className="text-gray-600">Sin datos.</p>}
+              ) : <p className="text-gray-600 dark:text-gray-400">Sin datos.</p>}
             </div>
 
             <div className="text-sm">
@@ -293,7 +293,7 @@ export default function FullExamPage() {
                   <li>Umbral de aprobación: ≤ {velSum.thresholdPct}%</li>
                   <li>Resultado: {velSum.pass ? 'Aprobado' : 'No aprobado'}</li>
                 </ul>
-              ) : <p className="text-gray-600">Sin datos.</p>}
+              ) : <p className="text-gray-600 dark:text-gray-400">Sin datos.</p>}
             </div>
 
             <div className="text-sm">
@@ -305,7 +305,7 @@ export default function FullExamPage() {
                   <li>Der: fuera {coordSum.right.outsideSec.toFixed(2)} s · salidas {coordSum.right.exits}</li>
                   <li>Resultado: {(coordSum.pass ?? coordSum.completed) ? 'Aprobado' : 'No aprobado'}</li>
                 </ul>
-              ) : <p className="text-gray-600">Sin datos.</p>}
+              ) : <p className="text-gray-600 dark:text-gray-400">Sin datos.</p>}
             </div>
 
             <div className="text-sm">
@@ -318,13 +318,19 @@ export default function FullExamPage() {
                   <li>Falsas alarmas: {attnSum.falseAlarms} · Inhibiciones correctas: {attnSum.correctInhibitions}</li>
                   <li>Resultado: {attnSum.pass ? 'Aprobado' : 'No aprobado'}</li>
                 </ul>
-              ) : <p className="text-gray-600">Sin datos.</p>}
+              ) : <p className="text-gray-600 dark:text-gray-400">Sin datos.</p>}
             </div>
           </div>
 
-          <div className={`p-3 rounded-xl ${overallPass ? 'bg-green-50 border border-green-200' : 'bg-red-50 border border-red-200'}`}>
+          <div
+            className={`p-3 rounded-xl ${
+              overallPass
+                ? 'bg-green-50 border border-green-200 dark:bg-green-900 dark:border-green-700'
+                : 'bg-red-50 border border-red-200 dark:bg-red-900 dark:border-red-700'
+            }`}
+          >
             <p className="font-semibold">Resultado final: {overallPass ? 'APROBADO' : 'NO APROBADO'}</p>
-            <p className="text-sm text-gray-700">
+            <p className="text-sm text-gray-700 dark:text-gray-300">
               Criterio: aprobar Teórico ({Math.round(THEORY_PASS_RATIO*100)}%), Señales ({Math.round(SIGNS_PASS_RATIO*100)}%) y todos los módulos psicofísicos.
             </p>
           </div>

--- a/src/pages/exam/SignsExamPage.tsx
+++ b/src/pages/exam/SignsExamPage.tsx
@@ -40,7 +40,7 @@ export default function SignsExamPage() {
     <section className="space-y-4">
       <h1 className="text-xl font-semibold">{t('exam.theory')}</h1>
       <ProgressBar value={idx + 1} max={data.length} />
-      <p className="text-sm text-gray-600">{t('exam.progress', { current: idx + 1, total: data.length })}</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">{t('exam.progress', { current: idx + 1, total: data.length })}</p>
 
       <QuestionCard
         q={q}
@@ -67,7 +67,7 @@ export default function SignsExamPage() {
       </div>
 
       {submitted && (
-        <div className="rounded-xl border p-4">
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-background p-4">
           <p className="font-semibold">{t('result.score', { score, total: data.length })}</p>
         </div>
       )}

--- a/src/pages/exam/TheoryExamPage.tsx
+++ b/src/pages/exam/TheoryExamPage.tsx
@@ -40,7 +40,7 @@ export default function TheoryExamPage() {
     <section className="space-y-4">
       <h1 className="text-xl font-semibold">{t('exam.theory')}</h1>
       <ProgressBar value={idx + 1} max={data.length} />
-      <p className="text-sm text-gray-600">{t('exam.progress', { current: idx + 1, total: data.length })}</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">{t('exam.progress', { current: idx + 1, total: data.length })}</p>
 
       <QuestionCard
         q={q}
@@ -67,7 +67,7 @@ export default function TheoryExamPage() {
       </div>
 
       {submitted && (
-        <div className="rounded-xl border p-4">
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-background p-4">
           <p className="font-semibold">{t('result.score', { score, total: data.length })}</p>
         </div>
       )}

--- a/src/ui/Card.tsx
+++ b/src/ui/Card.tsx
@@ -10,7 +10,7 @@ export default function Card({ children, className }: CardProps) {
   return (
     <div
       className={clsx(
-        'rounded-base border border-gray-200 dark:border-gray-700 bg-background text-foreground p-4',
+        'rounded-base border border-gray-200 dark:border-gray-700 bg-background text-foreground p-4 shadow-sm hover:shadow-md transition-shadow',
         className
       )}
     >

--- a/src/ui/Layout.tsx
+++ b/src/ui/Layout.tsx
@@ -4,7 +4,7 @@ import Footer from '../components/Footer'
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col bg-background text-foreground">
+    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors duration-300">
       <Header />
       <main className="flex-1 mx-auto w-full max-w-5xl px-4 py-6">{children}</main>
       <Footer />


### PR DESCRIPTION
## Summary
- add theme toggle with dark mode and persist preference
- modernize header, card, button and layout styling
- initialize theme from localStorage on page load

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d6c69984832b9d1c199e04455057